### PR TITLE
Diagrams rendered to same path as source file, added Preview as viewer

### DIFF
--- a/Diagram.sublime-settings
+++ b/Diagram.sublime-settings
@@ -1,0 +1,3 @@
+{
+	"viewer" : "Preview" // Preview, QuickLook or EyeOfGnome
+}

--- a/diagram/base.py
+++ b/diagram/base.py
@@ -1,7 +1,8 @@
 class BaseDiagram(object):
-    def __init__(self, processor, text):
+    def __init__(self, processor, sourceFile, text):
         self.proc = processor
         self.text = text
+        self.sourceFile = sourceFile
 
     def generate(self):
         raise NotImplementedError('abstract base class is abstract')
@@ -16,12 +17,12 @@ class BaseProcessor(object):
     def extract_blocks(self, view):
         raise NotImplementedError('abstract base class is abstract')
 
-    def process(self, text_blocks):
+    def process(self, sourceFile, text_blocks):
         diagrams = []
         for block in text_blocks:
             try:
                 print "Rendering diagram for block: %r" % block
-                diagram = self.DIAGRAM_CLASS(self, block)
+                diagram = self.DIAGRAM_CLASS(self, sourceFile, block)
                 rendered = diagram.generate()
                 diagrams.append(rendered)
             except Exception, e:

--- a/diagram/plantuml.py
+++ b/diagram/plantuml.py
@@ -7,9 +7,9 @@ from tempfile import NamedTemporaryFile
 
 
 class PlantUMLDiagram(BaseDiagram):
-    def __init__(self, processor, text):
-        super(PlantUMLDiagram, self).__init__(processor, text)
-        self.file = NamedTemporaryFile(suffix='.png')
+    def __init__(self, processor, sourceFile, text):
+        super(PlantUMLDiagram, self).__init__(processor, sourceFile, text)
+        self.file = NamedTemporaryFile(prefix=sourceFile,suffix='.png',delete=False)
 
     def generate(self):
         puml = execute(

--- a/diagram/preview.py
+++ b/diagram/preview.py
@@ -1,0 +1,16 @@
+from .base import BaseViewer
+import sys
+from subprocess import check_call, Popen as run_command
+
+
+class PreviewViewer(BaseViewer):
+    def load(self):
+        if sys.platform not in ('darwin',):
+            raise Exception("Currently only supported on MacOS")
+        if not check_call("which open > /dev/null", shell=True) == 0:
+            raise Exception("Can't find open")
+
+    def view(self, diagram_files):
+        displaycmd = ['open', '-a', 'Preview']
+        displaycmd.extend(diagram_file.name for diagram_file in diagram_files)
+        run_command(displaycmd).wait()


### PR DESCRIPTION
This might address #3. 

Diagrams are saved to files with the same as the source file — so for example from `source.c` you would get `source-Diagram-XXXX.png`, this would seem to be a sane naming convention?

I've also added in a settings file for choosing the viewer.
