### PR TITLE
set charset to UTF-8.

### DIFF
--- a/diagram/plantuml.py
+++ b/diagram/plantuml.py
@@ -18,7 +18,9 @@ class PlantUMLDiagram(BaseDiagram):
                 '-jar',
                 self.proc.plantuml_jar_path,
                 '-pipe',
-                '-tpng'
+                '-tpng',
+                '-charset',
+                'UTF-8'
             ],
             stdin=PIPE,
             stdout=self.file)


### PR DESCRIPTION
This pull request refers to #14 or @wubichu 's fork.
CJKV users write down uml text on their mother language in some case,
certainly it contains multi-byte characters.

It might not work properly at current commit, I think it's better that java options default to UTF-8.

It seems to be working so far on my Mac, and maybe no side effect.
