### PR TITLE
Save image to the same file when diagram is saved

### DIFF
--- a/Diagram.sublime-settings
+++ b/Diagram.sublime-settings
@@ -1,5 +1,7 @@
 {
+  // restart sublime to apply the changes
 	"viewer" : "Preview", // Preview, QuickLook, EyeOfGnome, WindowsDefaultViewer
 	"check_on_startup": true,
+  "new_file":false, // generate new file each time
 	"charset": null // Can be "UTF-8" - to support non-latin text in diagram
 }

--- a/diagram/__init__.py
+++ b/diagram/__init__.py
@@ -7,7 +7,7 @@ from .eog import EyeOfGnomeViewer
 from .freedesktop_default import FreedesktopDefaultViewer
 from .windows import WindowsDefaultViewer
 from threading import Thread
-from os.path import splitext
+# from os.path import splitext
 from sublime import error_message, load_settings
 import sys
 
@@ -41,6 +41,7 @@ def setup():
             proc = processor()
             proc.CHARSET = sublime_settings.get('charset')
             proc.CHECK_ON_STARTUP = sublime_settings.get('check_on_startup')
+            proc.NEW_FILE = sublime_settings.get('new_file')
             proc.load()
             ACTIVE_PROCESSORS.append(proc)
             print("Loaded processor: %r" % proc)
@@ -107,9 +108,9 @@ def process(view):
 
     if diagrams:
         sourceFile = view.file_name()
-        if sourceFile is None:
-            sourceFile = 'untitled.txt'
-        sourceFile = splitext(sourceFile)[0] + '-'
+        # if sourceFile is None:
+        #     sourceFile = 'untitled.txt'
+        # sourceFile = splitext(sourceFile)[0] + '-'
         t = Thread(target=render_and_view, args=(sourceFile, diagrams,))
         t.daemon = True
         t.start()

--- a/diagram/__init__.py
+++ b/diagram/__init__.py
@@ -7,7 +7,6 @@ from .eog import EyeOfGnomeViewer
 from .freedesktop_default import FreedesktopDefaultViewer
 from .windows import WindowsDefaultViewer
 from threading import Thread
-# from os.path import splitext
 from sublime import error_message, load_settings
 import sys
 
@@ -108,9 +107,6 @@ def process(view):
 
     if diagrams:
         sourceFile = view.file_name()
-        # if sourceFile is None:
-        #     sourceFile = 'untitled.txt'
-        # sourceFile = splitext(sourceFile)[0] + '-'
         t = Thread(target=render_and_view, args=(sourceFile, diagrams,))
         t.daemon = True
         t.start()

--- a/diagram/base.py
+++ b/diagram/base.py
@@ -12,6 +12,7 @@ class BaseProcessor(object):
     DIAGRAM_CLASS = None
     CHARSET = None
     CHECK_ON_STARTUP = True
+    NEW_FILE = False
 
     def load(self):
         raise NotImplementedError('abstract base class is abstract')

--- a/diagram/plantuml.py
+++ b/diagram/plantuml.py
@@ -2,7 +2,7 @@
 from .base import BaseDiagram
 from .base import BaseProcessor
 from subprocess import Popen as execute, PIPE, STDOUT, call
-from os.path import abspath, dirname, exists, join
+from os.path import abspath, dirname, exists, join, splitext
 from tempfile import NamedTemporaryFile
 from platform import system
 
@@ -14,7 +14,17 @@ EXTRA_CALL_ARGS = {'creationflags': CREATE_NO_WINDOW} if IS_MSWINDOWS else {}
 class PlantUMLDiagram(BaseDiagram):
     def __init__(self, processor, sourceFile, text):
         super(PlantUMLDiagram, self).__init__(processor, sourceFile, text)
-        self.file = NamedTemporaryFile(prefix=sourceFile, suffix='.png', delete=False)
+
+
+        if sourceFile is None:
+            self.file = NamedTemporaryFile(prefix='untitled', suffix='.png', delete=False)
+
+        else:
+            if self.proc.NEW_FILE:
+                self.file = NamedTemporaryFile(prefix=sourceFile, suffix='.png', delete=False)
+            else:
+                sourceFile = splitext(sourceFile)[0] + '.png'
+                self.file = open(mode='w', file=sourceFile)
 
     def generate(self):
         command = [
@@ -33,6 +43,7 @@ class PlantUMLDiagram(BaseDiagram):
             command.append("-charset")
             command.append(charset)
 
+        print("EEEE:", self.file)
         puml = execute(
             command,
             stdin=PIPE, stdout=self.file,

--- a/diagram/plantuml.py
+++ b/diagram/plantuml.py
@@ -62,7 +62,6 @@ class PlantUMLDiagram(BaseDiagram):
             command.append("-charset")
             command.append(charset)
 
-        print("EEEE:", self.file)
         puml = execute(
             command,
             stdin=PIPE, stdout=self.file,


### PR DESCRIPTION
Previously it creates new file every time. Now it overwrites existed one if diagram source is saved (not temporary file).
This option can be switched off.