### PR TITLE
Fix the exception when using Python2

### DIFF
--- a/diagram/plantuml.py
+++ b/diagram/plantuml.py
@@ -28,7 +28,7 @@ class PlantUMLDiagram(BaseDiagram):
                 self.file = NamedTemporaryFile(prefix=sourceFile, suffix='.png', delete=False)
             else:
                 sourceFile = splitext(sourceFile)[0] + '.png'
-                self.file = open(mode='w', file=sourceFile)
+                self.file = open(sourceFile, 'w')
 
     def generate(self):
         """


### PR DESCRIPTION
"file" is not a legal formal parameter in Python 2, which is
legal in Python 3. This kind of named parameter assignment
should be avoided to make this project staying compatible
with Python 2 & 3.

Signed-off-by: wwang <way_wang@outlook.com>